### PR TITLE
use title as logo

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -85,6 +85,11 @@ if (argv.logo) {
   site.logo = path.parse(argv.logo).base
 }
 
+/*
+* Add the title
+*/
+site.title = argv.title
+
 createOutputDir(function () {
   debug('createOutputDir')
   if (argv.logo) buildLogo()

--- a/components/header.js
+++ b/components/header.js
@@ -1,18 +1,21 @@
 var css = require('dom-css')
 
-module.exports = function (container, logo) {
+module.exports = function (container, logo, title) {
   var style = {
     header: {
       width: '100%',
       paddingLeft: '0%',
-      marginTop: '25px',
-      height: '10%',
-      marginBottom: '5px',
+      marginTop: '30px',
+      height: window.innerHeight * 0.09,
+      marginBottom: '10px',
       verticalAlign: 'top',
       display: 'inline-block'
     },
-    graphic: {
+    logo: {
       width: '200px'
+    },
+    title: {
+      fontSize: '300%'
     }
   }
 
@@ -21,8 +24,15 @@ module.exports = function (container, logo) {
   css(header, style.header)
   container.appendChild(header)
 
-  var graphic = document.createElement('img')
-  css(graphic, style.graphic)
-  graphic.src = logo
-  header.appendChild(graphic)
+  if (logo) {
+    var img = document.createElement('img')
+    css(img, style.logo)
+    img.src = logo
+    header.appendChild(img)
+  } else {
+    var div = document.createElement('div')
+    div.innerHTML = title
+    css(div, style.title)
+    header.appendChild(div)
+  }
 }

--- a/index.js
+++ b/index.js
@@ -16,14 +16,8 @@ module.exports = function (opts) {
   var logo = opts.logo
   var styles = opts.styles
   var initial = opts.initial
-  var title = opts.title
+  var title = opts.title || ''
   var node = opts.node || document.body
-
-  if (!title) {
-    console.log(process.cwd())
-    title = process.cwd().split('/')
-    title = title[title.length - 1]
-  }
 
   marked.setOptions({
     highlight: function (code) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,14 @@ module.exports = function (opts) {
   var logo = opts.logo
   var styles = opts.styles
   var initial = opts.initial
+  var title = opts.title
   var node = opts.node || document.body
+
+  if (!title) {
+    console.log(process.cwd())
+    title = process.cwd().split('/')
+    title = title[title.length - 1]
+  }
 
   marked.setOptions({
     highlight: function (code) {
@@ -60,7 +67,7 @@ module.exports = function (opts) {
   insertcss(githubcss)
   insertcss(highlightcss)
 
-  if (logo) require('./components/header')(container, logo)
+  require('./components/header')(container, logo, title)
   var sidebar = require('./components/sidebar')(container, contents)
   var main = require('./components/main')(container)
 


### PR DESCRIPTION
Use the title as logo as a fallback, so that the logo will either be an icon, or the name of the project, and if neither are defined, will just be an empty space.

Note that for the CLI usage the project title will default to the working directory, but when used as a module, the title will default to empty.