### PR TITLE
new sidebar design

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -15,7 +15,8 @@ module.exports = function (container, logo, title) {
       width: '200px'
     },
     title: {
-      fontSize: '300%'
+      fontSize: '300%',
+      fontFamily: 'clear_sans_mediumregular'
     }
   }
 
@@ -24,15 +25,20 @@ module.exports = function (container, logo, title) {
   css(header, style.header)
   container.appendChild(header)
 
+  var el
   if (logo) {
-    var img = document.createElement('img')
-    css(img, style.logo)
-    img.src = logo
-    header.appendChild(img)
+    el = document.createElement('img')
+    css(el, style.logo)
+    el.src = logo
+  } else if (title) {
+    el = document.createElement('div')
+    el.innerHTML = title
+    css(el, style.title)
   } else {
-    var div = document.createElement('div')
-    div.innerHTML = title
-    css(div, style.title)
-    header.appendChild(div)
+    el = document.createElement('div')
+    css(el, style.title)
+    css(header, {height: window.innerHeight * 0})
   }
+
+  header.appendChild(el)
 }

--- a/components/header.js
+++ b/components/header.js
@@ -7,7 +7,7 @@ module.exports = function (container, logo, title) {
       paddingLeft: '0%',
       marginTop: '30px',
       height: window.innerHeight * 0.09,
-      marginBottom: '10px',
+      marginBottom: '0px',
       verticalAlign: 'top',
       display: 'inline-block'
     },

--- a/components/main.js
+++ b/components/main.js
@@ -3,11 +3,12 @@ var css = require('dom-css')
 module.exports = function (container, documents) {
   var style = {
     wrapper: {
-      width: '60%',
-      height: window.innerHeight * 0.77,
+      width: '57%',
+      height: window.innerHeight * 0.75,
       paddingLeft: '6%',
-      paddingRight: '5%',
-      paddingTop: window.innerHeight * 0.03,
+      paddingRight: '10%',
+      paddingTop: window.innerHeight * 0.15,
+      paddingBottom: window.innerHeight * 0.1,
       verticalAlign: 'top',
       display: 'inline-block',
       overflowY: 'scroll'

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -7,23 +7,28 @@ var EventEmitter = require('events').EventEmitter
 module.exports = Sidebar
 inherits(Sidebar, EventEmitter)
 
-function Sidebar (container, contents) {
-  if (!(this instanceof Sidebar)) return new Sidebar(container, contents)
+function Sidebar (container, contents, logo, title) {
+  if (!(this instanceof Sidebar)) return new Sidebar(container, contents, logo, title)
   var self = this
 
   var style = {
     sidebar: {
-      width: '25%',
-      paddingLeft: '1%',
+      width: '24%',
+      paddingLeft: '3%',
       display: 'inline-block',
+      paddingBottom: window.innerHeight * 0.03,
       overflowY: 'scroll',
-      height: window.innerHeight * 0.8
+      background: 'rgb(240,240,240)',
+      height: window.innerHeight * 0.96
     },
     link: {
     }
   }
 
+  
   var sidebar = document.createElement('div')
+  var header = require('./header')(sidebar, logo, title)
+
   sidebar.className = 'minidocs-contents'
   iterate(sidebar, contents, -1)
 

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -7,16 +7,16 @@ body {
   padding-left: 2%;
   cursor: pointer;
   padding-bottom: 2px;
-  border-left: solid 4px rgb(240,240,240);
-  padding-right: 12px;
+  border-left: solid 1px rgb(240,240,240);
+  padding-right: 10px;
 }
 
 .contents-link:hover {
-  border-left: solid 4px rgb(255,255,255);
+  border-left: dotted 1px rgb(40,40,40);
 }
 
 .contents-link-selected {
-  border-left: solid 4px rgb(255,255,255);
+  border-left: dotted 1px rgb(40,40,40);
   background: rgb(255,255,255);
 }
 

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -7,7 +7,8 @@ body {
   padding-left: 2%;
   cursor: pointer;
   padding-bottom: 2px;
-  border-left: solid 1px white;
+  border-left: solid 1px rgb(240,240,240);
+  padding-right: 5px;
 }
 
 .contents-link:hover {
@@ -16,7 +17,6 @@ body {
 
 .contents-link-selected {
   border-left: dotted 1px black;
-  color: rgb(0,0,0);
 }
 
 ::-webkit-scrollbar {

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -7,16 +7,14 @@ body {
   padding-left: 2%;
   cursor: pointer;
   padding-bottom: 2px;
-  border-left: solid 1px rgb(240,240,240);
   padding-right: 10px;
 }
 
 .contents-link:hover {
-  border-left: dotted 1px rgb(40,40,40);
+  background: rgb(255,255,255);
 }
 
 .contents-link-selected {
-  border-left: dotted 1px rgb(40,40,40);
   background: rgb(255,255,255);
 }
 

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -8,7 +8,7 @@ body {
   cursor: pointer;
   padding-bottom: 2px;
   border-left: solid 4px rgb(240,240,240);
-  padding-right: 5px;
+  padding-right: 12px;
 }
 
 .contents-link:hover {

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -7,16 +7,17 @@ body {
   padding-left: 2%;
   cursor: pointer;
   padding-bottom: 2px;
-  border-left: solid 1px rgb(240,240,240);
+  border-left: solid 4px rgb(240,240,240);
   padding-right: 5px;
 }
 
 .contents-link:hover {
-  border-left: dotted 1px black;
+  border-left: solid 4px rgb(255,255,255);
 }
 
 .contents-link-selected {
-  border-left: dotted 1px black;
+  border-left: solid 4px rgb(255,255,255);
+  background: rgb(255,255,255);
 }
 
 ::-webkit-scrollbar {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (opts) {
   container.className = 'minidocs'
   node.appendChild(container)
   css(node, {margin: '0px', padding: '0px'})
-  css(container, {width: '90%', marginLeft: '5%', marginRight: '5%'})
+  css(container, {width: '100%', marginLeft: '0%', marginRight: '0%'})
 
   if (styles) insertcss(styles)
 
@@ -61,8 +61,7 @@ module.exports = function (opts) {
   insertcss(githubcss)
   insertcss(highlightcss)
 
-  require('./components/header')(container, logo, title)
-  var sidebar = require('./components/sidebar')(container, contents)
+  var sidebar = require('./components/sidebar')(container, contents, logo, title)
   var main = require('./components/main')(container)
 
   sidebar.on('selected', function (key) {


### PR DESCRIPTION
Proposal for an alternate design of the sidebar (and overall layout). It puts the table of contents behind a shaded region. It's a bit more similar to classic documentation sites, and a bit more traditional, but maybe easier to understand. Although I liked the minimalism of the current version, with the new one, I find my eyes are more easily guided to the right place.

Here are screenshots from a full doc site before and after the change.

![screen shot 2016-04-05 at 10 51 02 am](https://cloud.githubusercontent.com/assets/3387500/14286439/054e3324-fb1d-11e5-9577-6711fdf45b5a.png)


![screen shot 2016-04-05 at 10 53 28 am](https://cloud.githubusercontent.com/assets/3387500/14286443/09a1fb0e-fb1d-11e5-88e0-ab08905a648b.png)

And here's a live site with the new layout 

http://docs.thunder-project.org/

Suggested by @sofroniewn.