### PR TITLE
use inherits from util

### DIFF
--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -1,5 +1,5 @@
 var css = require('dom-css')
-var inherits = require('inherits')
+var inherits = require('util').inherits
 var foreach = require('lodash.foreach')
 var isobject = require('lodash.isobject')
 var EventEmitter = require('events').EventEmitter


### PR DESCRIPTION
### Context

When running the `npm start` command from example, I got 

```
~/code/opensource/minidocs(master|…) 😾  npm start

> minidocs@1.0.0 start /Users/fraserxu/code/opensource/minidocs
> budo index.js:bundle.js

[0000] info  Server running at http://10.23.1.183:9966/ (connect)
Error: Cannot find module 'inherits' from '/Users/fraserxu/code/opensource/minidocs/node_modules/minidocs/components'
```

I'm running the command on nodejs `v4.4.3` and from the documentation `inherits` is under the core `util` module.

https://nodejs.org/dist/latest-v4.x/docs/api/util.html#util_util_inherits_constructor_superconstructor

It could be fixed by changing the require path to `util` like in this pull request, or the other way is to include `inherits` module from npm. 