### PR TITLE
cli windows support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,18 +2,19 @@
 
 var fs = require('fs')
 var path = require('path')
-var includeFolder = require('include-folder')
+var read = require('read-directory')
+var parsePath = require('parse-filepath')
 var html = require('simple-html-index')
 var browserify = require('browserify')
 var minimist = require('minimist')
 var mkdir = require('mkdirp')
 var rm = require('rimraf')
+var exit = require('exit')
 var debug = require('debug')('minidocs:cli')
 
 var cwd = process.cwd()
-var cwdArr = cwd.split('/')
-var projectdir = cwdArr[cwdArr.length - 1]
-
+var cwdParsed = parsePath(cwd)
+var projectdir = cwdParsed.name
 var argv = minimist(process.argv.slice(2), {
   alias: {
     c: 'contents',
@@ -51,7 +52,7 @@ var site = {
 */
 if (argv.help) {
   console.log(usage)
-  process.exit()
+  exit()
 }
 
 /*
@@ -59,11 +60,11 @@ if (argv.help) {
 */
 if (argv._[0]) {
   var source = path.resolve(cwd, argv._[0])
-  site.markdown = includeFolder(source)
+  site.markdown = read.sync(source, { extensions: false })
 } else {
   console.log('\nError:\nsource markdown directory is required')
   console.log(usage)
-  process.exit()
+  exit()
 }
 
 /*
@@ -75,7 +76,7 @@ if (argv.contents) {
 } else {
   console.log('\nError:\n--contents/-c option is required')
   console.log(usage)
-  process.exit()
+  exit()
 }
 
 /*
@@ -168,5 +169,5 @@ function buildLogo () {
 
 function error (err) {
   console.log(err)
-  process.exit(1)
+  exit(1)
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "browserify": "^13.0.0",
     "camelcase": "^2.1.1",
     "dom-css": "^2.0.0",
+    "exit": "^0.1.2",
     "folderify": "^1.2.0",
     "from2-string": "^1.1.0",
     "highlight.js": "^9.2.0",
@@ -54,6 +55,8 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "os-tmpdir": "^1.0.1",
+    "parse-filepath": "^1.0.1",
+    "read-directory": "^1.2.0",
     "rimraf": "^2.5.2",
     "simple-html-index": "^1.2.0"
   },


### PR DESCRIPTION
This makes a few changes to the cli tool to make it work on windows.

- uses [read-directory](http://npmjs.com/read-directory) instead of [include-folder](http://npmjs.com/include-folder), which had some path regex issues
- parses cwd path instead of splitting by `/`
- uses [exit](http://npmjs.com/exit) instead of `process.exit`