### PR TITLE
set a basedir, fix trailing slash bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Options:
   * --initial, -i      Page to use for root url
   * --pushstate, -p    Create a 200.html file for hosting services like surge.sh
   * --basedir, -b      Base directory of the site
+  * --full-html, -f    Create HTML files for all routes. Useful for GitHub Pages. [false]
   * --help, -h         Show this help message
 ```
 
@@ -198,11 +199,13 @@ GitHub Pages doesn't support HTML5 pushstate, so you have two options:
 
 ##### 1. Generate the site with the minidocs cli
 
-To create a minidocs site with the cli:
+Build a minidocs site with the cli and the `--full-html` option:
 
 ```sh
-minidocs path/to/docs/dir -c contents.json -o site
+minidocs path/to/docs/dir -c contents.json -o site --full-html
 ```
+
+This creates an HTML file for each route of the site, so that on initial page load all content is sent from the server, and once the JS is loaded the minidocs app takes over all routing.
 
 ##### 2. Use hash routing with the JS module
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Options:
   * --logo, -l         Project logo
   * --css, -s          Optional stylesheet
   * --initial, -i      Page to use for root url
-  * --pushstate, p     Create a 200.html file for hosting services like surge.sh
+  * --pushstate, -p    Create a 200.html file for hosting services like surge.sh
+  * --basedir, -b      Base directory of the site
   * --help, -h         Show this help message
 ```
 
@@ -215,6 +216,8 @@ document.body.appendChild(tree)
 ##### Deploy with the `gh-pages` command
 
 You can use the [`gh-pages`](https://www.npmjs.com/package/gh-pages) module to push the built site to the gh-pages branch of your repo.
+
+> Note: if you're deploying a project at a basedir like username.github.io/project-name, you'll want to use the `--basedir /project-name` option
 
 Install `gh-pages`:
 

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var parseDocs = require('./lib/parse-docs')
 var main = require('./components/main')
 
 module.exports = function (opts) {
+  opts.basedir = opts.basedir.replace(/\/$/, '') || ''
   var app = choo()
   var docs = parseDocs(opts)
 
@@ -15,9 +16,9 @@ module.exports = function (opts) {
       markdown: docs.markdown,
       html: docs.html,
       routes: docs.routes,
-      current: opts.initial || Object.keys(docs.markdown)[0]
-    },
-    reducers: {}
+      current: opts.initial || Object.keys(docs.markdown)[0],
+      basedir: opts.basedir
+    }
   })
 
   app.router(function (route) {
@@ -26,6 +27,6 @@ module.exports = function (opts) {
       route('/:page', main)
     ]
   })
-
+``
   return app
 }

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ var parseDocs = require('./lib/parse-docs')
 var main = require('./components/main')
 
 module.exports = function (opts) {
-  opts.basedir = opts.basedir.replace(/\/$/, '') || ''
+  opts.basedir = (opts.basedir || '').replace(/\/$/, '')
   var app = choo()
   var docs = parseDocs(opts)
 
@@ -27,6 +27,6 @@ module.exports = function (opts) {
       route('/:page', main)
     ]
   })
-``
+
   return app
 }

--- a/app.js
+++ b/app.js
@@ -22,10 +22,16 @@ module.exports = function (opts) {
   })
 
   app.router(function (route) {
-    return [
+    var routes = [
       route('/', main),
       route('/:page', main)
     ]
+
+    if (opts.basedir) {
+      return route(opts.basedir, routes)
+    }
+
+    return routes
   })
 
   return app

--- a/cli.js
+++ b/cli.js
@@ -28,12 +28,14 @@ var argv = minimist(process.argv.slice(2), {
     i: 'initial',
     p: 'pushstate',
     b: 'basedir',
+    e: 'extensions',
     h: 'help'
   },
   default: {
     output: 'site',
     title: projectdir,
-    basedir: ''
+    basedir: '',
+    extensions: false
   }
 })
 
@@ -108,9 +110,7 @@ function buildHTML (done) {
   Object.keys(docs.routes).forEach(function (key) {
     state.contents = docs.contents
     var route = docs.routes[key]
-    var dirpath = path.join(outputDir, route)
-    var filepath = path.join(dirpath, 'index.html')
-    console.log('route', route)
+    var filepath = path.join(outputDir, key + '.html')
     var page = app.toString(state.basedir + route, state)
 
     var html = createHTML({
@@ -120,12 +120,9 @@ function buildHTML (done) {
       css: argv.basedir + '/bundle.css'
     })
 
-    mkdir(dirpath, function (err) {
+    fs.writeFile(filepath, html, function (err) {
       if (err) error(err)
-      fs.writeFile(filepath, html, function (err) {
-        if (err) error(err)
-        done()
-      })
+      done()
     })
   })
 }

--- a/cli.js
+++ b/cli.js
@@ -65,7 +65,8 @@ var state = {
   logo: logo,
   contents: require(contentsPath),
   markdown: markdown,
-  initial: argv.initial || Object.keys(markdown)[0]
+  initial: argv.initial || Object.keys(markdown)[0],
+  basedir: argv.basedir
 }
 
 var docs = parseDocs(state)
@@ -109,13 +110,14 @@ function buildHTML (done) {
     var route = docs.routes[key]
     var dirpath = path.join(outputDir, route)
     var filepath = path.join(dirpath, 'index.html')
-    var page = app.toString(route, state)
+    console.log('route', route)
+    var page = app.toString(state.basedir + route, state)
 
     var html = createHTML({
       title: state.title,
       body: page,
-      script: '/' + argv.basedir + '/bundle.js',
-      css: '/' + argv.basedir + '/bundle.css'
+      script: argv.basedir + '/bundle.js',
+      css: argv.basedir + '/bundle.css'
     })
 
     mkdir(dirpath, function (err) {
@@ -186,8 +188,8 @@ function createPushstateFile (done) {
   var html = createHTML({
     title: state.title,
     body: page,
-    script: '/' + argv.basedir + '/bundle.js',
-    css: '/' + argv.basedir + '/bundle.css'
+    script: argv.basedir + '/bundle.js',
+    css: argv.basedir + '/bundle.css'
   })
 
   fs.writeFile(pushstatefile, html, function (err) {

--- a/cli.js
+++ b/cli.js
@@ -27,11 +27,13 @@ var argv = minimist(process.argv.slice(2), {
     s: 'css',
     i: 'initial',
     p: 'pushstate',
+    b: 'basedir',
     h: 'help'
   },
   default: {
     output: 'site',
-    title: projectdir
+    title: projectdir,
+    basedir: ''
   }
 })
 
@@ -81,7 +83,8 @@ function usage (exitcode) {
     * --logo, -l         Project logo
     * --css, -s          Optional stylesheet
     * --initial, -i      Page to use for root url
-    * --pushstate, p     Create a 200.html file for hosting services like surge.sh
+    * --pushstate, -p    Create a 200.html file for hosting services like surge.sh
+    * --basedir, -b      Base directory of the site
     * --help, -h         Show this help message
   `)
   exit(exitcode || 0)
@@ -111,8 +114,8 @@ function buildHTML (done) {
     var html = createHTML({
       title: state.title,
       body: page,
-      script: '/bundle.js',
-      css: '/bundle.css'
+      script: '/' + argv.basedir + '/bundle.js',
+      css: '/' + argv.basedir + '/bundle.css'
     })
 
     mkdir(dirpath, function (err) {
@@ -183,8 +186,8 @@ function createPushstateFile (done) {
   var html = createHTML({
     title: state.title,
     body: page,
-    script: '/bundle.js',
-    css: '/bundle.css'
+    script: '/' + argv.basedir + '/bundle.js',
+    css: '/' + argv.basedir + '/bundle.css'
   })
 
   fs.writeFile(pushstatefile, html, function (err) {

--- a/cli.js
+++ b/cli.js
@@ -111,6 +111,7 @@ function buildHTML (done) {
     state.contents = docs.contents
     var route = docs.routes[key]
     var filepath = path.join(outputDir, key + '.html')
+    state.current = key === 'index' ? state.initial : key
     var page = app.toString(state.basedir + route, state)
 
     var html = createHTML({

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -76,7 +76,7 @@ module.exports = function (params, state, send) {
   function createHeader () {
     if (state.logo) {
       return el`
-        <img class="minidocs-logo" src="${state.logo}" alt="${state.title}">
+        <img class="minidocs-logo" src="${state.basedir + '/' + state.logo}" alt="${state.title}">
       `
     }
     return state.title

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -99,9 +99,7 @@ module.exports = function (params, state, send) {
       }
 
       if (item.link) {
-        return el`<div>
-          <a href="${item.link}" class="content-link ${isActive(current, item.key)}">${item.name}</a>
-        </div>`
+        return el`<div><a href="${item.link}" class="content-link ${isActive(current, item.key)}">${item.name}</a></div>`
       }
 
       return el`<div class="h${item.depth}">${item.name}</div>`

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -90,7 +90,8 @@ module.exports = function (params, state, send) {
 
       if (state.app && state.app.location) {
         location = url.parse(state.app.location)
-        current = location.pathname.slice(1)
+        var sliceBy = state.basedir.length + 1
+        current = location.pathname.slice(sliceBy)
       }
 
       if (!current || current.length <= 1) {

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -113,7 +113,7 @@ module.exports = function (params, state, send) {
 
   return el`<div class="${prefix} minidocs-sidebar">
     <div class="minidocs-header">
-      <h1><a href="/">${createHeader()}</a></h1>
+      <h1><a href="${state.basedir}/">${createHeader()}</a></h1>
     </div>
     <div class="minidocs-contents">
       ${createMenu(contents)}

--- a/lib/parse-contents.js
+++ b/lib/parse-contents.js
@@ -2,7 +2,8 @@ var parsePath = require('parse-filepath')
 var isobject = require('lodash.isobject')
 var map = require('lodash.map')
 
-module.exports = function parseContents (contents) {
+module.exports = function parseContents (options) {
+  var contents = options.contents
   var depth = 0
   var menu = []
 
@@ -29,7 +30,7 @@ module.exports = function parseContents (contents) {
       }
       var parsed = parsePath(value)
       obj.key = parsed.name
-      obj.link = '/' + obj.key
+      obj.link = options.basedir + '/' + obj.key
       menu.push(obj)
     }
     return menu

--- a/lib/parse-docs.js
+++ b/lib/parse-docs.js
@@ -3,10 +3,11 @@ var parseMarkdown = require('./parse-markdown')
 
 module.exports = function (options) {
   if (!options || !options.contents || !options.markdown) {
-    throw new Error('options object with contents and markdown properties')
+    throw new Error('options object with contents and markdown properties is required')
   }
-  var contents = parseContents(options.contents)
-  var documents = parseMarkdown(options.contents, options.markdown)
+
+  var contents = parseContents(options)
+  var documents = parseMarkdown(options)
 
   var routes = { index: '/' }
   contents.forEach(function (item) {

--- a/lib/parse-markdown.js
+++ b/lib/parse-markdown.js
@@ -9,7 +9,9 @@ marked.setOptions({
   }
 })
 
-module.exports = function parseMarkdown (contents, markdown) {
+module.exports = function parseMarkdown (options) {
+  var contents = options.contents
+  var markdown = options.markdown
   var html = {}
 
   Object.keys(markdown).forEach(function (key) {


### PR DESCRIPTION
closes #29 

This adds a `basedir` option to the cli & js api.

Primarily for use with gh-pages or anytime a site it being published at a subdirectory like `username.github.io/project-name/`