### PR TITLE
Make sure window is defined

### DIFF
--- a/components/menu.js
+++ b/components/menu.js
@@ -124,7 +124,7 @@ module.exports = function (state, prev, send) {
   }
 
   function isOpen () {
-    if (window.innerWidth > 600) return 'menu-open'
+    if (typeof window !== 'undefined' && window.innerWidth > 600) return 'menu-open'
     return state.menu.open ? 'menu-open' : 'menu-closed'
   }
 


### PR DESCRIPTION
Window is not defined in node so building pages fails:

```bash
> minidocs . -c contents.json -i welcome -o dist -l dat-data.png -t 'The Dat Project' -s styles.css --full-html

/Users/joe/node_modules/minidocs/components/menu.js:127
    if (window && window.innerWidth > 600) return 'menu-open'
        ^

ReferenceError: window is not defined
    at isOpen (/Users/joe/node_modules/minidocs/components/menu.js:127:9)
    at module.exports (/Users/joe/node_modules/minidocs/components/menu.js:137:33)
    at module.exports (/Users/joe/node_modules/minidocs/components/sidebar.js:86:7)
    at module.exports (/Users/joe/node_modules/minidocs/components/main.js:41:7)
    at chooWrap (/Users/joe/node_modules/minidocs/node_modules/choo/index.js:139:18)
    at emit (/Users/joe/node_modules/minidocs/node_modules/wayfarer/index.js:48:22)
    at match (/Users/joe/node_modules/minidocs/node_modules/sheet-router/index.js:55:19)
    at Function.toString (/Users/joe/node_modules/minidocs/node_modules/choo/index.js:49:18)
    at createFile (/Users/joe/node_modules/minidocs/cli.js:115:20)
    at /Users/joe/node_modules/minidocs/cli.js:135:7

```