### PR TITLE
Fix languages that aren't registered

### DIFF
--- a/lib/parse-markdown.js
+++ b/lib/parse-markdown.js
@@ -3,10 +3,19 @@ var hl = require('./highlight')
 
 marked.setOptions({
   highlight: function (code, lang) {
-    var out = lang ? hl.highlight(lang, code) : hl.highlightAuto(code)
-    return out.value
+    try {
+      return highlight(code, lang)
+    } catch (e) {
+      hl.registerLanguage(lang, require('highlight.js/lib/languages/' + lang))
+      return highlight(code, lang)
+    }
   }
 })
+
+function highlight (code, lang) {
+  var out = lang ? hl.highlight(lang, code) : hl.highlightAuto(code)
+  return out.value
+}
 
 module.exports = function parseMarkdown (markdown) {
   if (!markdown) return ''


### PR DESCRIPTION
We had a markdown doc with `protobuf` highlighting. Since that wasn't included in the specified highlight bundles, minidocs failed.

This PR registers languages that fail. It works for the CLI but I'm not sure if this will work client-side. Maybe it should just be a silent fail?

Error being fixed:

```
> minidocs . -c contents.json -i welcome -o dist -l dat-data.png -t 'The Dat Project' -s styles.css --full-html

/Users/joe/node_modules/minidocs/node_modules/marked/lib/marked.js:1226
    throw e;
    ^

Error: Unknown language: "protobuf"
Please report this to https://github.com/chjj/marked.
    at Object.highlight (/Users/joe/node_modules/minidocs/node_modules/highlight.js/lib/highlight.js:495:13)
    at Object.marked.setOptions.highlight (/Users/joe/node_modules/minidocs/lib/parse-markdown.js:6:25)
    at Renderer.code (/Users/joe/node_modules/minidocs/node_modules/marked/lib/marked.js:766:28)
    at Parser.tok (/Users/joe/node_modules/minidocs/node_modules/marked/lib/marked.js:990:28)
    at Parser.parse (/Users/joe/node_modules/minidocs/node_modules/marked/lib/marked.js:935:17)
    at Function.Parser.parse (/Users/joe/node_modules/minidocs/node_modules/marked/lib/marked.js:922:17)
    at marked (/Users/joe/node_modules/minidocs/node_modules/marked/lib/marked.js:1218:19)
    at parseMarkdown (/Users/joe/node_modules/minidocs/lib/parse-markdown.js:13:10)
    at /Users/joe/node_modules/minidocs/lib/parse-docs.js:19:25
    at Array.forEach (native)
```
 

