### PR TITLE
Force y scroll to prevent sidebar changing width

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -3,6 +3,7 @@ body {
   color: rgb(80,80,80);
   margin: 0px;
   padding: 0px;
+  overflow-y: scroll;
 }
 
 .contents-link {


### PR DESCRIPTION
Currently the sidebar panel will change widths when navigating between pages that have scroll bars vs those that don't. This forces scrollbar to have width always so sidebar doesn't jump.