### PR TITLE
Make sure opts is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function (opts) {
         opts = id
         id = null
       }
+      if (!opts) opts = {}
       opts.href = opts.href || false
       return app.start(id, opts)
     }


### PR DESCRIPTION
`opts` is not always defined, so I am getting an error when opening a page:

```
Cannot read property 'href' of undefined
```

Should it always be defined...?