### PR TITLE
Fix sub TOC links for special characters

### DIFF
--- a/lib/parse-markdown.js
+++ b/lib/parse-markdown.js
@@ -1,15 +1,16 @@
 var marked = require('marked')
 var hl = require('highlight.js')
+var slugify = require('slug')
 var renderer = new marked.Renderer()
 
 var toc = []
 
 renderer.heading = function(text, level, raw) {
-  var slug = text.toLowerCase().replace(/[^\w]+/g, '-')
+  var slug = slugify(raw, {lower: true})
   toc.push({
     level: level,
     slug: slug,
-    title: text
+    title: raw
   })
   return "<h" + level + " id=\"" + slug + "\"><a href=\"#" + slug + "\" class=\"anchor\"></a>" + text + "</h" + level + ">"
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "rimraf": "^2.5.2",
     "sheetify": "^5.0.2",
     "sheetify-cssnext": "^1.0.7",
+    "slug": "^0.9.1",
     "static-module": "^1.3.1",
     "tar": "^2.2.1",
     "tar-fs": "^1.13.2",


### PR DESCRIPTION
This PR fixes the TOC links and text display for headings with special characters ([example](http://docs.datproject.org/faq#security-amp-privacy)). 

Before we were using the markdown processed text. This uses the raw text and sluglifies the link (replacing the hacky regex).