### PR TITLE
fix callback handling in createAssets

### DIFF
--- a/lib/create-assets.js
+++ b/lib/create-assets.js
@@ -26,7 +26,7 @@ module.exports = function createAssets (app, options, callback) {
   function copyAssets (fn) {
     var pack = tar.pack(assets)
     var extract = tar.extract(path.join(outputDir, assetsPath.name))
-    pack.pipe(extract).on('end', fn)
+    pack.pipe(extract).on('finish', fn)
   }
 
   if (logoSource && assets) {


### PR DESCRIPTION
`tar-fs` doesn't provide an event type `end` but uses `finish` instead. As a result, the callback of `createAssets()` was never called such that `createPushstateFile()` is unreachable when used together with assets: https://github.com/freeman-lab/minidocs/blob/63bd43b4f0cc8900845525cb5b08eaac4b6b42bf/bin/index.js#L101-L105